### PR TITLE
fix teammates' class not displaying on scoreboard when they're dead

### DIFF
--- a/src/game/client/tf/vgui/tf_clientscoreboard.cpp
+++ b/src/game/client/tf/vgui/tf_clientscoreboard.cpp
@@ -1129,14 +1129,7 @@ void CTFClientScoreBoardDialog::UpdatePlayerList()
 
 					if ( iClass >= TF_FIRST_NORMAL_CLASS && iClass <= TF_LAST_NORMAL_CLASS )
 					{
-						if ( bAlive )
-						{
-							pKeyValues->SetString("class", g_aPlayerClassNames[iClass]);
-						}
-						else
-						{
-							pKeyValues->SetString("class", "");
-						}
+						pKeyValues->SetString("class", g_aPlayerClassNames[iClass]);
 					}
 					else
 					{


### PR DESCRIPTION
stupid oversight i made, but i blame valve for their STUPID codebase throwing me off